### PR TITLE
Add mechanisms for FontRegistryKey derivation in registry and IFont

### DIFF
--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -2,11 +2,17 @@
 pragma solidity ^0.8.13;
 
 import "forge-std/Script.sol";
+import "src/FontRegistry.sol";
 
 contract Deploy is Script {
-    function setUp() public {}
+
+    FontRegistry fontRegistry;
 
     function run() public {
-        vm.broadcast();
+        vm.startBroadcast();
+
+        fontRegistry = new FontRegistry();
+        
+        vm.stopBroadcast();
     }
 }

--- a/src/FontRegistry.sol
+++ b/src/FontRegistry.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
+import {IFontRegistry} from "./interfaces/IFontRegistry.sol";
 import {IFont} from "./interfaces/IFont.sol";
 import {OwnableRoles} from "solady/auth/OwnableRoles.sol";
 
@@ -24,7 +25,7 @@ import {OwnableRoles} from "solady/auth/OwnableRoles.sol";
 /// All credits will be given to the font uploaders.
 ///
 /// @author @0x_beans
-contract FontRegistry is OwnableRoles {
+contract FontRegistry is OwnableRoles, IFontRegistry {
     // keccak256(fontName) => address of base64 encoded font
     mapping(bytes32 => address) public fonts;
 

--- a/src/FontRegistry.sol
+++ b/src/FontRegistry.sol
@@ -35,9 +35,7 @@ contract FontRegistry is OwnableRoles {
     /// @dev only owners (maintainers) of the registry can add fonts after properly verifying the font
     /// @param fontAddress address of the IFont contract
     function addFontToRegistry(address fontAddress) external onlyOwner {
-        fonts[
-            keccak256(abi.encodePacked(IFont(fontAddress).fontName()))
-        ] = fontAddress;
+        fonts[keccak256(abi.encodePacked(IFont(fontAddress).fontName()))] = fontAddress;
     }
 
     /// @dev only owners (maintainers) of the registry can delete fonts from the registry
@@ -51,11 +49,13 @@ contract FontRegistry is OwnableRoles {
     /// @dev query existing fonts in the registry (searchable on the website)
     /// @param fontName font name as found on the website
     /// @dev returns base64 encoded string of the font
-    function getFont(string calldata fontName)
-        external
-        view
-        returns (string memory)
-    {
-        return IFont(fonts[keccak256(abi.encodePacked(fontName))]).getFont();
+    function getFont(string calldata fontName) external view returns (string memory) {
+        return IFont(fonts[getFontKey(fontName)]).getFont();
+    }
+
+    /// @dev derive the font's 32 byte key from its name, for use with the `fonts` storage mapping
+    /// @param fontName font name as found on the website
+    function getFontKey(string calldata fontName) public pure returns (bytes32) {
+        return keccak256(abi.encodePacked(fontName));
     }
 }

--- a/src/examples/exampleFont.sol
+++ b/src/examples/exampleFont.sol
@@ -29,7 +29,7 @@ contract ExampleFont is OwnableRoles, IFont {
     ==============================================================*/
 
     // credit to the person that uploaded the font
-    address public fontUploader = msg.sender;
+    address public immutable fontUploader = msg.sender;
 
     // Note: below doesn't follow the convenction of ALL CAPS for constants
     // if you want to follow convention, just write explicit functions for the interface
@@ -48,16 +48,16 @@ contract ExampleFont is OwnableRoles, IFont {
     // any standard descriptor of the font style
     string public constant fontStyle = "normal";
 
+    // key of this Font in the FontRegistry's storage mapping
+    bytes32 public constant fontRegistryKey = keccak256(abi.encodePacked(fontName));
+
     /*==============================================================
     ==                      Custom Font Logic                     ==
     ==============================================================*/
 
     // function the script calls to uplod the different partitions to contract storage
     // check exampleFontUpload.js to see how we upload fonts
-    function saveFile(uint256 index, string calldata fileContent)
-        external
-        onlyOwner
-    {
+    function saveFile(uint256 index, string calldata fileContent) external onlyOwner {
         files[index] = SSTORE2.write(bytes(fileContent));
     }
 
@@ -72,15 +72,14 @@ contract ExampleFont is OwnableRoles, IFont {
 
     // reconstruct full font and return it
     function getFont() external view returns (string memory) {
-        return
-            string(
-                abi.encodePacked(
-                    SSTORE2.read(files[0]),
-                    SSTORE2.read(files[1]),
-                    SSTORE2.read(files[2]),
-                    SSTORE2.read(files[3]),
-                    SSTORE2.read(files[4])
-                )
-            );
+        return string(
+            abi.encodePacked(
+                SSTORE2.read(files[0]),
+                SSTORE2.read(files[1]),
+                SSTORE2.read(files[2]),
+                SSTORE2.read(files[3]),
+                SSTORE2.read(files[4])
+            )
+        );
     }
 }

--- a/src/interfaces/IFont.sol
+++ b/src/interfaces/IFont.sol
@@ -30,4 +30,7 @@ interface IFont {
 
     // return the full base64 encoded font with data uri scheme prefix (`data:font/ttf;charset=utf-8;base64,`)
     function getFont() external view returns (string memory);
+
+    // returns this font's key in the FontRegistry's storage mapping
+    function fontRegistryKey() external view returns (bytes32);
 }

--- a/src/interfaces/IFontRegistry.sol
+++ b/src/interfaces/IFontRegistry.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+/// @title The FontRegistry interface
+/// @dev Useful as a lightweight dependency import without drastically increasing runtime bytecode
+/// @author 📯📯📯.eth
+
+interface IFontRegistry {
+    function getFont(string calldata fontName) external view returns (string memory);
+
+    /// @dev Gated functions (restricted to the owner only)
+    function addFontToRegistry(address fontAddress) external;
+    function deleteFontFromRegistry(address fontAddress) external;
+}

--- a/src/interfaces/IFontRegistry.sol
+++ b/src/interfaces/IFontRegistry.sol
@@ -7,6 +7,7 @@ pragma solidity ^0.8.13;
 
 interface IFontRegistry {
     function getFont(string calldata fontName) external view returns (string memory);
+    function getFontKey(string calldata fontName) external pure returns (bytes32);
 
     /// @dev Gated functions (restricted to the owner only)
     function addFontToRegistry(address fontAddress) external;


### PR DESCRIPTION
FontRegistryKey convenience functions provide a straightforward way to fetch the relevant mapping key for a given font name. Should improve devX and 

Updates to the example font file, minor optimizations (immutable var), and ran the `forge fmt` linter